### PR TITLE
Pascal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,9 @@ An empty default means the global default is used.
 <tr>
   <td>php</td><td>PHP5</td><td></td><td>['--no-php-ini']</td>
 </tr>
+<tr>
+  <td>pascal</td><td>Free Pascal</td><td>['-vew', '-Se']</td><td></td>
+</tr>
 
 </table>
 ## Configuration

--- a/application/libraries/pascal_task.php
+++ b/application/libraries/pascal_task.php
@@ -17,14 +17,12 @@ class C_Task extends Task {
     public function __construct($source, $filename, $input, $params) {
         Task::__construct($source, $filename, $input, $params);
         $this->default_params['compileargs'] = array(
-            '-Wall',
-            '-Werror',
-            '-std=c99',
-            '-x c');
+            '-vew', // [v]erbose, [e]rrors, [w]arnings
+            '-Se'); // stop on first error
     }
 
     public static function getVersion() {
-        return 'fpc';
+        return 'fpc-2.6.0'; // maybe something like 'fpc-' . exec('fpc -iV') to get correct version?
     }
 
     public function compile() {
@@ -33,7 +31,7 @@ class C_Task extends Task {
         $execFileName = "$src.exe";
         $compileargs = $this->getParam('compileargs');
 //        $cmd = "gcc " . implode(' ', $compileargs) . " -o $execFileName $src -lm 2>$errorFileName";
-        $cmd = "fpc " . implode(' ', $compileargs) . " -o $execFileName $src -lm 2>$errorFileName";
+        $cmd = "fpc " . implode(' ', $compileargs) . " -o$execFileName $src 2>$errorFileName";
         exec($cmd, $output, $returnVar);
         if ($returnVar == 0) {
             $this->cmpinfo = '';
@@ -46,7 +44,7 @@ class C_Task extends Task {
 
     // A default name for C programs
     public function defaultFileName($sourcecode) {
-        return 'prog.c';
+        return 'prog.pas';
     }
     
     

--- a/application/libraries/pascal_task.php
+++ b/application/libraries/pascal_task.php
@@ -31,7 +31,8 @@ class Pascal_Task extends Task {
         $execFileName = "$src.exe";
         $compileargs = $this->getParam('compileargs');
 //        $cmd = "gcc " . implode(' ', $compileargs) . " -o $execFileName $src -lm 2>$errorFileName";
-        $cmd = "fpc " . implode(' ', $compileargs) . " -o$execFileName $src 2>$errorFileName";
+        $cmd = "fpc " . implode(' ', $compileargs) . " -Fe$errorFileName -o$execFileName $src";
+	// -Fe[filename] - store error log in file
         exec($cmd, $output, $returnVar);
         if ($returnVar == 0) {
             $this->cmpinfo = '';

--- a/application/libraries/pascal_task.php
+++ b/application/libraries/pascal_task.php
@@ -1,0 +1,62 @@
+<?php defined('BASEPATH') OR exit('No direct script access allowed');
+
+/* ==============================================================
+ *
+ * Pascal
+ *
+ * ==============================================================
+ *
+ * @copyright  2015 Fedor Lyanguzov, based on 2014 Richard Lobb, University of Canterbury
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once('application/libraries/LanguageTask.php');
+
+class C_Task extends Task {
+
+    public function __construct($source, $filename, $input, $params) {
+        Task::__construct($source, $filename, $input, $params);
+        $this->default_params['compileargs'] = array(
+            '-Wall',
+            '-Werror',
+            '-std=c99',
+            '-x c');
+    }
+
+    public static function getVersion() {
+        return 'fpc';
+    }
+
+    public function compile() {
+        $src = basename($this->sourceFileName);
+        $errorFileName = "$src.err";
+        $execFileName = "$src.exe";
+        $compileargs = $this->getParam('compileargs');
+//        $cmd = "gcc " . implode(' ', $compileargs) . " -o $execFileName $src -lm 2>$errorFileName";
+        $cmd = "fpc " . implode(' ', $compileargs) . " -o $execFileName $src -lm 2>$errorFileName";
+        exec($cmd, $output, $returnVar);
+        if ($returnVar == 0) {
+            $this->cmpinfo = '';
+            $this->executableFileName = $execFileName;
+        }
+        else {
+            $this->cmpinfo = file_get_contents($errorFileName);
+        }
+    }
+
+    // A default name for C programs
+    public function defaultFileName($sourcecode) {
+        return 'prog.c';
+    }
+    
+    
+    // The executable is the output from the compilation
+    public function getExecutablePath() {
+        return "./" . $this->executableFileName;
+    }
+    
+    
+    public function getTargetFile() {
+        return '';
+    }
+};

--- a/application/libraries/pascal_task.php
+++ b/application/libraries/pascal_task.php
@@ -12,7 +12,7 @@
 
 require_once('application/libraries/LanguageTask.php');
 
-class C_Task extends Task {
+class Pascal_Task extends Task {
 
     public function __construct($source, $filename, $input, $params) {
         Task::__construct($source, $filename, $input, $params);
@@ -42,7 +42,7 @@ class C_Task extends Task {
         }
     }
 
-    // A default name for C programs
+    // A default name for Pascal programs
     public function defaultFileName($sourcecode) {
         return 'prog.pas';
     }

--- a/testsubmit.py
+++ b/testsubmit.py
@@ -19,7 +19,7 @@ VERBOSE = False
 # Set DEBUGGING to True to instruct Jobe to use debug mode, i.e., to
 # leave all runs (commands, input output etc) in /home/jobe/runs, rather
 # than deleting each run as soon as it is done.
-DEBUGGING = True
+DEBUGGING = False
 
 # Set JOBE_SERVER to the Jobe server URL.
 # If Jobe expects an X-API-Key header, set API_KEY to a working value and set
@@ -31,7 +31,7 @@ JOBE_SERVER = 'localhost'
 
 # Set the next line to a specific value, e.g. 'octave' to restrict to testing
 # just one language. Use 'ALL' to test all languages.
-TEST_LANG = 'pascal'
+TEST_LANG = 'ALL'
 
 GOOD_TEST = 0
 FAIL_TEST = 1

--- a/testsubmit.py
+++ b/testsubmit.py
@@ -31,7 +31,7 @@ JOBE_SERVER = 'localhost'
 
 # Set the next line to a specific value, e.g. 'octave' to restrict to testing
 # just one language. Use 'ALL' to test all languages.
-TEST_LANG = 'ALL'
+TEST_LANG = 'pascal'
 
 GOOD_TEST = 0
 FAIL_TEST = 1
@@ -558,6 +558,18 @@ int main() {
 ''',
     'sourcefilename': 'prog.c',
     'expect': { 'outcome': 11 }
+},
+
+#================ Pascal tests ====================
+{
+    'comment': 'Hello world Pascal test',
+    'language_id': 'pascal',
+    'sourcecode': r'''begin
+writeln('Hello world!');
+end.
+''',
+    'sourcefilename': 'prog.pas',
+    'expect': { 'outcome': 15, 'stdout': "Hello world!\n" }
 }
 
 ]

--- a/testsubmit.py
+++ b/testsubmit.py
@@ -19,7 +19,7 @@ VERBOSE = False
 # Set DEBUGGING to True to instruct Jobe to use debug mode, i.e., to
 # leave all runs (commands, input output etc) in /home/jobe/runs, rather
 # than deleting each run as soon as it is done.
-DEBUGGING = False
+DEBUGGING = True
 
 # Set JOBE_SERVER to the Jobe server URL.
 # If Jobe expects an X-API-Key header, set API_KEY to a working value and set
@@ -562,7 +562,7 @@ int main() {
 
 #================ Pascal tests ====================
 {
-    'comment': 'Hello world Pascal test',
+    'comment': 'Good Hello world Pascal test',
     'language_id': 'pascal',
     'sourcecode': r'''begin
 writeln('Hello world!');
@@ -570,6 +570,17 @@ end.
 ''',
     'sourcefilename': 'prog.pas',
     'expect': { 'outcome': 15, 'stdout': "Hello world!\n" }
+},
+
+{
+    'comment': 'Fail Hello world Pascal test',
+    'language_id': 'pascal',
+    'sourcecode': r'''begin
+writeln('Hello world!);
+end.
+''',
+    'sourcefilename': 'prog.pas',
+    'expect': { 'outcome': 11 }
 }
 
 ]


### PR DESCRIPTION
Hello again, Richard.

This pull request is about adding Pascal language support to Jobe server.

This is my first attempt at participation in open source development, so please be forgiving. I'm starting this pull request very early to make a place for conversation.

The goal is to make Pascal questions work as much like C-program questions as possible.

I see my development plan as:
1) Choose an open source Pascal compiler.
2) Add a task to jobe/application/libraries.
3) Make a test submit (in testsubmit.py?)

The choice of compiler is from:
1) [GNU Pascal](http://www.gnu-pascal.de/gpc/h-index.html)
2) [Free Pascal](http://www.freepascal.org/)
I have chosen Free Pascal because it has a live community, and i have some experience using it. I have installed it with:
```sudo apt-get install fp-compiler```
[Debian Wheezy 7.8 fp-compiler package](https://packages.debian.org/wheezy/fp-compiler-2.6.0)
Note: i see no reason in installing `fpc`(full package), because it has an IDE in it, while only compiler will be used.

I have created language task for Pascal based on c_task.php. While modifying it, i was stopped by a question, which i can't answer myself (even with Google). What is the meaning of `-lm` flag of gcc (c_task.php, line 35)?
```$cmd = "gcc " . implode(' ', $compileargs) . " -o $execFileName $src -lm 2>$errorFileName";```
I have only one idea: it's a `-l` link library flag, with `m` library. 

On a side note, how should i create a CodeRunner Pascal-program question, with Moodle interface or just by copying and editing c_program prototype in built-in protos?

Sincerely yours,
Fedor