### PR TITLE
added '-r' to the useradd argument to ensure jobe-created accounts are system accounts 

### DIFF
--- a/install
+++ b/install
@@ -84,7 +84,7 @@ def make_user(username, comment, make_home_dir=False, group='jobe'):
             group_opt = ''
         else:
             group_opt = ' -g ' + group
-        do_command('useradd {} -s "/bin/false"{} -c "{}" {}'.format(opt, group_opt, comment, username))
+        do_command('useradd -r {} -s "/bin/false"{} -c "{}" {}'.format(opt, group_opt, comment, username))
 
 
 def make_directory(dirpath, webuser):


### PR DESCRIPTION
This pull request will address the issue #12 of jobe-created accounts being automatically deleted by central management systems such as puppet