### PR TITLE
explicitly specify permission of /home/jobe 

### DIFF
--- a/install
+++ b/install
@@ -137,6 +137,8 @@ def main():
             print("Web server is", webserver_user)
             print("Make user jobe")
             make_user('jobe', 'Jobe user. Provides home for runs.', True, None)
+            # make sure www-data can reach /home/jobe/runs despite it is not in jobe group
+            do_command("chmod 755 /home/jobe")
             print("Setting up file cache")
             make_directory('{}/files'.format(install_dir), webserver_user);
 


### PR DESCRIPTION
…h /home/jobe/runs despite it is not in the jobe group.  This is necessary in systems that have a more restrictive default permission than a standard Linux installation  This will fix issue #17 