### PR TITLE
VHDL support

### DIFF
--- a/application/libraries/vhdl_task.php
+++ b/application/libraries/vhdl_task.php
@@ -20,8 +20,7 @@ class VHDL_Task extends Task {
             // '-fsynopsys', // The use of non standard library will not produce an error -> Not recognized on command line
             '--ieee=standard',
             '--mb-comments', // Allow UTF8 or multi-bytes chars in a comment.
-			'-C', // See above
-			'-fno-caret-diagnostics' // Remove source line of error
+			'-C' // See above
             );
     }
 

--- a/application/libraries/vhdl_task.php
+++ b/application/libraries/vhdl_task.php
@@ -51,4 +51,11 @@ class VHDL_Task extends Task {
     public function getTargetFile() {
         return '';
     }
+    
+    // Remove time and type of report information to leave only the message
+    public function filteredStdout() {
+	$parts = explode(':', $this->stdout);
+	array_splice($parts, 0, 5);
+	return trim(implode(':', $parts));
+    }
 };

--- a/application/libraries/vhdl_task.php
+++ b/application/libraries/vhdl_task.php
@@ -1,0 +1,55 @@
+<?php defined('BASEPATH') OR exit('No direct script access allowed');
+
+/* ==============================================================
+ *
+ * VHDL
+ *
+ * ==============================================================
+ *
+ * @copyright  2020 Clément Leboulenger, based on 2014 Richard Lobb, University of Canterbury
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once('application/libraries/LanguageTask.php');
+
+class VHDL_Task extends Task {
+
+    public function __construct($filename, $input, $params) {
+        parent::__construct($filename, $input, $params);
+        $this->default_params['compileargs'] = array(
+            // '-fsynopsys', // The use of non standard library will not produce an error -> Not recognized on command line
+            '--ieee=standard',
+            '--mb-comments', // Allow UTF8 or multi-bytes chars in a comment.
+			'-C', // See above
+			'-fno-caret-diagnostics' // Remove source line of error
+            );
+    }
+
+    public static function getVersionCommand() {
+        return array('ghdl-gcc --version', '/GHDL ([0-9.]*)/');
+    }
+
+    public function compile() {
+        $src = basename($this->sourceFileName);
+        $this->executableFileName = $execFileName = "$src.exe";
+        $compileargs = $this->getParam('compileargs');
+        $cmd = "ghdl-gcc " . "-c " . implode(' ', $compileargs) . " -o $execFileName $src " . "-e test_bench" ; // The top entity must be named test_bench
+        list($output, $this->cmpinfo) = $this->run_in_sandbox($cmd);
+    }
+
+    // A default name for VHDL programs
+    public function defaultFileName($sourcecode) {
+        return 'prog.vhd';
+    }
+
+
+    // The executable is the output from the compilation
+    public function getExecutablePath() {
+        return "./" . $this->executableFileName;
+    }
+
+
+    public function getTargetFile() {
+        return '';
+    }
+};

--- a/application/libraries/vhdl_task.php
+++ b/application/libraries/vhdl_task.php
@@ -54,8 +54,12 @@ class VHDL_Task extends Task {
     
     // Remove time and type of report information to leave only the message
     public function filteredStdout() {
-	$parts = explode(':', $this->stdout);
-	array_splice($parts, 0, 5);
-	return trim(implode(':', $parts));
+		$lines = explode(PHP_EOL, $this->stdout);
+		foreach($lines as &$line) {
+			$tmp = explode(':', $line);
+			array_splice($tmp, 0, 5);
+			$line = trim(implode(':', $tmp));
+		}
+		return implode(PHP_EOL, $lines);
     }
 };

--- a/application/libraries/vhdl_task.php
+++ b/application/libraries/vhdl_task.php
@@ -20,7 +20,7 @@ class VHDL_Task extends Task {
             // '-fsynopsys', // The use of non standard library will not produce an error -> Not recognized on command line
             '--ieee=standard',
             '--mb-comments', // Allow UTF8 or multi-bytes chars in a comment.
-			'-C' // See above
+            '-C' // See above
             );
     }
 
@@ -54,12 +54,12 @@ class VHDL_Task extends Task {
     
     // Remove time and type of report information to leave only the message
     public function filteredStdout() {
-		$lines = explode(PHP_EOL, $this->stdout);
-		foreach($lines as &$line) {
-			$tmp = explode(':', $line);
-			array_splice($tmp, 0, 5);
-			$line = trim(implode(':', $tmp));
-		}
-		return implode(PHP_EOL, $lines);
+        $lines = explode(PHP_EOL, $this->stdout);
+        foreach($lines as &$line) {
+            $tmp = explode(':', $line);
+            array_splice($tmp, 0, 5);
+            $line = trim(implode(':', $tmp));
+        }
+        return implode(PHP_EOL, $lines);
     }
 };

--- a/testsubmit.py
+++ b/testsubmit.py
@@ -788,7 +788,7 @@ port map ( I      => I,
 end BEHAVIOUR;
 ''',
     'sourcefilename' : 'prog.vhd',
-    'expect' : {'outcome' : 15 , 'stdout' : "End of test. Verify that no error was reported."
+    'expect' : {'outcome' : 15 , 'stdout' : "End of test. Verify that no error was reported.\n"
     }
 }
 

--- a/testsubmit.py
+++ b/testsubmit.py
@@ -700,6 +700,96 @@ end.
 ''',
     'sourcefilename': 'prog.pas',
     'expect': { 'outcome': 11 }
+},
+
+#================ VHDL tests ====================
+{
+    'comment' : 'MUX41 test bench',
+    'language_id' : 'vhdl',
+    'sourcecode' : r'''LIBRARY ieee;
+USE ieee.std_logic_1164.all;
+USE ieee.numeric_std.all;
+
+
+entity MUX41 IS
+port(
+    I : in std_logic_vector(3 downto 0);
+    SEL : in std_logic_vector(1 downto 0);
+    Y : out std_logic);
+END MUX41 ;
+
+
+architecture BEHAVIOUR of MUX41 is
+begin
+    with SEL select
+        Y <=    I(0) when "00",
+                I(1) when "01",
+                I(2) when "10",
+                I(3) when "11",
+                '-' when others;
+end BEHAVIOUR;
+
+LIBRARY ieee;
+USE ieee.std_logic_1164.all;
+USE ieee.numeric_std.all;
+
+entity TEST_BENCH IS
+
+END TEST_BENCH ;
+
+architecture BEHAVIOUR of TEST_BENCH is
+
+    signal I : std_logic_vector(3 downto 0);
+    signal SEL :  std_logic_vector(1 downto 0);
+    signal Y :  std_logic;
+
+begin
+    process
+    begin
+        SEL <= "00";
+        for j in 0 to 15 loop
+            I <= std_logic_vector(to_unsigned(j,4));
+            assert Y=I(0) report "Error on I(0)" severity warning; 
+            wait for 10 ns;
+        end loop;
+        
+        SEL <= "01";
+        for j in 0 to 15 loop
+            I <= std_logic_vector(to_unsigned(j,4));
+            assert Y=I(1) report "Error on I(1)" severity warning;
+            wait for 10 ns;
+        end loop;
+        
+        SEL <= "10";
+        for j in 0 to 15 loop
+            I <= std_logic_vector(to_unsigned(j,4));
+            assert Y=I(2) report "Error on I(2)" severity warning;
+            wait for 10 ns;
+        end loop;
+        
+        SEL <= "11";
+        for j in 0 to 15 loop
+            I <= std_logic_vector(to_unsigned(j,4));
+            assert Y=I(3) report "Error on I(3)" severity warning;
+            wait for 10 ns;
+        end loop;
+        
+        
+        report "End of test. Verify that no error was reported.";
+        wait;
+        
+    end process;
+    
+UUT : entity work.MUX41
+port map ( I      => I,
+           SEL      => SEL,
+           Y  => Y);
+		
+end BEHAVIOUR;
+''',
+    'sourcefilename' : 'prog.vhd',
+    'expect' : {'outcome' : 15 , 'stdout' : "prog.vhd:70:9:@640ns:(report note): End of test. Verify that no error was reported.\n"
+    }
 }
 
 ]

--- a/testsubmit.py
+++ b/testsubmit.py
@@ -788,7 +788,7 @@ port map ( I      => I,
 end BEHAVIOUR;
 ''',
     'sourcefilename' : 'prog.vhd',
-    'expect' : {'outcome' : 15 , 'stdout' : "prog.vhd:70:9:@640ns:(report note): End of test. Verify that no error was reported.\n"
+    'expect' : {'outcome' : 15 , 'stdout' : "End of test. Verify that no error was reported."
     }
 }
 


### PR DESCRIPTION
Hello,

My professors, my classmate and I are planning to add VHDL type questions to Coderunner. With this pull request, we want to add VHDL language support to Jobe.

We chose [ghdl-gcc](https://github.com/ghdl/ghdl) as a compiler because it's free and it fully supports the main version of the language. I installed it with `apt-get install ghdl-gcc` on Ubuntu 20.04.

To compile a VHDL program, we must provide the name of the top entity to the compiler. I chose to put a limitation on it, so that the name of the top entity must be named *test_bench*. Therefore, the name of the entity will be defined in the coderunner template, so that the teacher will only have to write the architecture of his test bench in the Test case field.

I also added a unit test (4 to 1 multiplexer with test bench) in testsubmit.py.

Regards,
Clément Leboulenger