### PR TITLE
Fixed check if sourcefilename is valid

### DIFF
--- a/application/controllers/Restapi.php
+++ b/application/controllers/Restapi.php
@@ -152,7 +152,7 @@ class Restapi extends REST_Controller {
                 !isset($run['language_id']) ) {
             $this->error('runs_post: invalid run specification', 400);
         }
-        if (isset($run->sourcefilename) && !self::is_valid_source_filename($run->sourcefilename)) {
+        if (isset($run['sourcefilename']) && !self::is_valid_source_filename($run['sourcefilename'])) {
             $this->error('runs_post: invalid sourcefilename');
         }
 


### PR DESCRIPTION
When the server checks if sourcefilename is valid it treats the **run** variable as an object but during the check the variable is not an object yet. So it will never check the filename. 
This will fix #46 
