### PR TITLE
Accept C Task solutions with warnings

### DIFF
--- a/application/controllers/Restapi.php
+++ b/application/controllers/Restapi.php
@@ -219,7 +219,7 @@ class Restapi extends REST_Controller {
                 $this->log('debug', "runs_post: compiling job {$this->task->id}");
                 $this->task->compile();
 
-                if (empty($this->task->cmpinfo)) {
+                if ($this->task->isRunnable()) {
                     $this->log('debug', "runs_post: executing job {$this->task->id}");
                     $this->task->execute();
                 }

--- a/application/libraries/LanguageTask.php
+++ b/application/libraries/LanguageTask.php
@@ -462,10 +462,15 @@ abstract class Task {
         }
     }
 
+    // Check if the task can be run
+
+    public function isRunnable() {
+      return empty($this->cmpinfo);
+    }
 
     // Return the JobeAPI result object to describe the state of this task
     public function resultObject() {
-        if ($this->cmpinfo) {
+        if (!$this->isRunnable()) {
             $this->result = Task::RESULT_COMPILATION_ERROR;
         }
         return new ResultObject(

--- a/application/libraries/c_task.php
+++ b/application/libraries/c_task.php
@@ -14,11 +14,12 @@ require_once('application/libraries/LanguageTask.php');
 
 class C_Task extends Task {
 
+    public $runnable = false;
+
     public function __construct($filename, $input, $params) {
         parent::__construct($filename, $input, $params);
         $this->default_params['compileargs'] = array(
             '-Wall',
-            '-Werror',
             '-std=c99',
             '-x c');
     }
@@ -27,13 +28,25 @@ class C_Task extends Task {
         return array('gcc --version', '/gcc \(.*\) ([0-9.]*)/');
     }
 
+    public function isRunnable() {
+      return $this->runnable;
+    }
+
     public function compile() {
         $src = basename($this->sourceFileName);
         $this->executableFileName = $execFileName = "$src.exe";
         $compileargs = $this->getParam('compileargs');
         $linkargs = $this->getParam('linkargs');
         $cmd = "gcc " . implode(' ', $compileargs) . " -o $execFileName $src " . implode(' ', $linkargs);
+        if (file_exists($this->getExecutablePath())) {
+          unlink($this->getExecutablePath());
+          log_message("error", "Runnable should not exist before compilation!");
+        }
+        $this->runnable = false;
         list($output, $this->cmpinfo) = $this->run_in_sandbox($cmd);
+        if (file_exists($this->getExecutablePath())) {
+          $this->runnable = true;
+        }
     }
 
     // A default name for C programs


### PR DESCRIPTION
For compiling languages, it seem fair enough to accept solutions with warnings, because warnings by nature are not errors, codes with warnings totally can works correctly (ofcourse as probably can contain logical mistake). For example the gets function, although everybody knows about the warning that it can not be used safely, but in educational exercises with explicit limits in requirements the situations are different, but there are no way to make the linker silence about this and thereafter Jobe treats warnings as errors, in combination people have no choices, and it's not right in the open world, so i think it should be fixed, and i tend to fix the problem with C task first in this commit.