### PR TITLE
Add main_class param to Java task.

### DIFF
--- a/application/libraries/java_task.php
+++ b/application/libraries/java_task.php
@@ -24,7 +24,7 @@ class Java_Task extends Task {
              "-Xss8m",
              "-Xmx200m"
         );
-        $this->default_params['main_class'] = FALSE;
+        $this->default_params['main_class'] = null;
 
         if (isset($params['numprocs']) && $params['numprocs'] < 256) {
             $params['numprocs'] = 256;  // Minimum for Java 8 JVM

--- a/application/libraries/java_task.php
+++ b/application/libraries/java_task.php
@@ -24,6 +24,7 @@ class Java_Task extends Task {
              "-Xss8m",
              "-Xmx200m"
         );
+        $this->default_params['main_class'] = FALSE;
 
         if (isset($params['numprocs']) && $params['numprocs'] < 256) {
             $params['numprocs'] = 256;  // Minimum for Java 8 JVM
@@ -74,7 +75,7 @@ class Java_Task extends Task {
 
 
     public function getTargetFile() {
-        return $this->mainClassName;
+        return $this->getParam('main_class') ?? $this->mainClassName;
     }
 
 


### PR DESCRIPTION
Hello, I don't know if this will be something of interest to you but I needed it for a thing I'm building.

This change adds a new parameter to Java tasks, `main_class` that can be used to specify a different class to run with `java` than the one whose source just came in. The incoming source is still compiled but this allows me to, for instance, run a test runner class that takes the name of the incoming class as an argument (which I pass via `runargs`) and then exercises the code submitted rather than running it directly.

Since this parameter only has any affect if it is set this should be completely backwards compatible.

If you want this, I'm happy to add some docs wherever is appropriate to make it a first class thing.