### PR TITLE
Extra options and runguard header fix

### DIFF
--- a/application/config/config.php
+++ b/application/config/config.php
@@ -549,5 +549,31 @@ $config['python3_version'] = 'python3'; # /usr/bin/<python3_version> is the pyth
 // might be hidden away in a systemd-private directory, depending on your Linux
 // version).
 
+/*
+|--------------------------------------------------------------------------
+| Jobe parameters: CPU pinning for jobs
+|--------------------------------------------------------------------------
+|
+| This section of the config file controls processor affinity, i.e. pinning
+| runguard tasks to a particular CPU core.
+|
+| The way task are pinned is to use the jobe user id modulo the number of 
+| cores. Under a load which requires more compute than is available
+| this yields linear slowdown for each job. Assigning jobs to a specific
+| core yields more predictable behaviour during extreme overallocation.
+| This is more significant with machines that have multi-socket CPUs 
+| which can have larger memory/cache penalites when tasks are transferred 
+| between cores.
+|
+| Consider setting jobe_max_users to be a multiple of num_cores, otherwise 
+| there will be imbalance under 100% job allocation.
+|
+| Enabling this option restricts each job to a singular core, regardless 
+| of number of spawned threads. Multiple threads will work fine but they 
+| cannot run perfectly concurrent, a context switch must occur.
+*/
+$config['cpu_pinning_enabled'] = FALSE; 
+$config['cpu_pinning_num_cores'] = 16; // Update to number of server cores
+
 /* End of file config.php */
 /* Location: ./application/config/config.php */

--- a/application/config/config.php
+++ b/application/config/config.php
@@ -575,5 +575,19 @@ $config['python3_version'] = 'python3'; # /usr/bin/<python3_version> is the pyth
 $config['cpu_pinning_enabled'] = FALSE; 
 $config['cpu_pinning_num_cores'] = 16; // Update to number of server cores
 
+/*
+|--------------------------------------------------------------------------
+| Jobe parameters: Extra Java/Javac arguments
+|--------------------------------------------------------------------------
+|
+| This section of the config file adds extra flags to java and javac
+|
+| Provided examples tells java/javac that there is only 1 core, which 
+| reduces the number of spawned threads when compiling. This option can be 
+| used to provide a better experience when many users are using jobe.
+*/
+$config['javac_extraflags'] = ''; //'-J-XX:ActiveProcessorCount=1'; 
+$config['java_extraflags'] = ''; //'-XX:ActiveProcessorCount=1';
+
 /* End of file config.php */
 /* Location: ./application/config/config.php */

--- a/application/libraries/LanguageTask.php
+++ b/application/libraries/LanguageTask.php
@@ -276,12 +276,22 @@ abstract class Task {
      * from running the given command.
      */
     public function run_in_sandbox($wrappedCmd, $iscompile=true, $stdin=null) {
+        global $CI;
+
         $filesize = 1000 * $this->getParam('disklimit', $iscompile); // MB -> kB
         $streamsize = 1000 * $this->getParam('streamsize', $iscompile); // MB -> kB
         $memsize = 1000 * $this->getParam('memorylimit', $iscompile);
         $cputime = $this->getParam('cputime', $iscompile);
         $killtime = 2 * $cputime; // Kill the job after twice the allowed cpu time
         $numProcs = $this->getParam('numprocs', $iscompile) + 1; // The + 1 allows for the sh command below.
+
+        // CPU pinning - only active if enabled 
+        $sandboxCpuPinning = array();
+        if($CI->config->item('cpu_pinning_enabled') == TRUE) {
+            $taskset_core_id = intval($this->userId) % intval($CI->config->item('cpu_pinning_num_cores'));
+            $sandboxCpuPinning = array("taskset --cpu-list " . $taskset_core_id);
+        }
+
         $sandboxCommandBits = array(
                 "sudo " . dirname(__FILE__)  . "/../../runguard/runguard",
                 "--user={$this->user}",
@@ -292,6 +302,9 @@ abstract class Task {
                 "--nproc=$numProcs",       // Max num processes/threads for this *user*
                 "--no-core",
                 "--streamsize=$streamsize");   // Max stdout/stderr sizes
+
+        // Prepend CPU pinning command if enabled
+        $sandboxCommandBits = array_merge($sandboxCpuPinning, $sandboxCommandBits);
 
         if ($memsize != 0) {  // Special case: Matlab won't run with a memsize set. TODO: WHY NOT!
             $sandboxCommandBits[] = "--memsize=$memsize";

--- a/install
+++ b/install
@@ -154,6 +154,18 @@ def do_purge(install_dir):
     do_command('rm -rf {}/files'.format(install_dir), ignore_errors=True)
     do_command('rm -rf ' + FILE_CACHE_BASE + '/*', ignore_errors=True)
 
+def update_runguard_config(install_dir, num_jobe_users):
+    # Make sure the number of valid users are matching our num jobe users
+    print("Settig up runguard config")
+    runguard_users = ["domjudge", "jobe"] + ['jobe{:02d}'.format(i) for i in range(num_jobe_users)]
+    with open(os.path.join(install_dir, "runguard/runguard-config.h"), "r") as runguard_config_in:
+        runguard_config = runguard_config_in.read()
+
+    runguard_valid_users = ",".join(runguard_users)
+
+    runguard_config = re.sub("#define\s+VALID_USERS[^\n]+", '#define VALID_USERS "' + runguard_valid_users + '"', runguard_config)
+    with open(os.path.join(install_dir, "runguard/runguard-config.h"), "w") as runguard_config_out:
+        runguard_config_out.write(runguard_config)
 
 def make_workers(num_jobe_users, max_uid):
     """Make the Jobe worker users"""
@@ -178,6 +190,9 @@ def create_jobe_user_and_files(install_dir, webserver_user, max_uid):
     make_directory('/home/jobe/files', 'jobe', webserver_user)
     print("Setting up Jobe log directory (/var/log/jobe)")
     make_directory('/var/log/jobe', 'jobe', webserver_user)
+
+
+
 
 
 def process_command_line_args():
@@ -233,6 +248,7 @@ def main():
         make_directory(FILE_CACHE_BASE, 'jobe', webserver_user)
 
         print("Building runguard")
+        update_runguard_config(install_dir, num_jobe_users)
         make_runguard(install_dir)
         
         make_sudoers(install_dir, webserver_user, num_jobe_users)


### PR DESCRIPTION
This is a rewrite of the changes we have made to our production Jobe server at the Dept. of Computer Science, Lund University.

We have used CodeRunner in Moodle using mostly Java questions with Jobe as our execution backend. We have successfully used Jobe with these changes during exams with more than 300 students.

I have tested these specific changes using [JobeInABox](https://github.com/trampgeek/jobeinabox) with a custom config:
- Enabled CPU pinning (which is included in this pull request), 24 cores
- Enabled global Java/Javac options with the option used in comment. These tells java that there is only one processor which is fine for us and it does reduce the number of spawned threads.
- Max number of jobe users were set to 128, the test server used had 24 logical processors (2 sockets)

The tests I have performed are:
- The simple test of running python3 /var/www/html/jobe/testsubmit.py - passed.
- Load test by using java questions with data written by humans, i.e. not synthetic. At 4x times load (1x being 100% available compute) it is stable with 96 users submitting a question continuously with 1 sec wait before next attempt. 128 users (5.3x overload) with same conditions has a 4.5% failure rate due to compile timeout but it is a highly unrealistic one when we compare to real usage. We have never seen above 2x load during real usage but it is directly proportional to the number of users and more users will eventually require more compute.