### PR TITLE
Fix SyntaxWarning in Python 3.12

### DIFF
--- a/install
+++ b/install
@@ -164,7 +164,7 @@ def update_runguard_config(install_dir, num_jobe_users):
 
     runguard_valid_users = ",".join(runguard_users)
 
-    runguard_config = re.sub("#define\s+VALID_USERS[^\n]+", '#define VALID_USERS "' + runguard_valid_users + '"', runguard_config)
+    runguard_config = re.sub(r"#define\s+VALID_USERS[^\n]+", '#define VALID_USERS "' + runguard_valid_users + '"', runguard_config)
     with open(os.path.join(install_dir, "runguard/runguard-config.h"), "w") as runguard_config_out:
         runguard_config_out.write(runguard_config)
 


### PR DESCRIPTION
Hi,
I noticed that Python 3.12 shows `SyntaxWarning: invalid escape sequence '\s'` for `runguard_config = re.sub("#define\s+VALID_USERS[^\n]+", '#define VALID_USERS "' + runguard_valid_users + '"', runguard_config)` in install script. I fixed it to avoid possible problems in the future.

> A backslash-character pair that is not a valid escape sequence now generates a SyntaxWarning, instead of DeprecationWarning. For example, re.compile("\d+\.\d+") now emits a SyntaxWarning ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")). In a future Python version, SyntaxError will eventually be raised, instead of SyntaxWarning. (Contributed by Victor Stinner in gh-98401.)

https://docs.python.org/dev/whatsnew/3.12.html#other-language-changes