### PR TITLE
Display a newline instead of \n in PHP task

### DIFF
--- a/application/libraries/php_task.php
+++ b/application/libraries/php_task.php
@@ -32,7 +32,7 @@ class Php_Task extends Task {
             $this->executableFileName = $this->sourceFileName;
         } else {
             if ($output) {
-                $this->cmpinfo = $output . '\n' . $compileErrs;
+                $this->cmpinfo = $output . "\n" . $compileErrs;
             } else {
                 $this->cmpinfo = $compileErrs;
             }


### PR DESCRIPTION
The change is mostly cosmetic, but now, instead of `\n` string, a real new line will be printed before the error message.