### PR TITLE
Improve test perfomance granularity2

### DIFF
--- a/testsubmit.py
+++ b/testsubmit.py
@@ -779,10 +779,12 @@ def check_file(file_id):
                 content =  response.read(4096)
             output(f"{response.status} {response.reason} {content}")
 
-        connect.close()
 
     except HTTPError:
         return -1
+    finally:
+        if connect:
+            connect.close()
 
     return response.status
 
@@ -883,7 +885,6 @@ def do_http(method, resource, data=None):
                 result = json.loads(content)
         if isinstance(result, str):
             result = str(response.status) + ': ' + result
-        connect.close()
 
     except (HTTPError, ValueError) as e:
         output("\n***************** HTTP ERROR ******************\n")
@@ -892,6 +893,10 @@ def do_http(method, resource, data=None):
         else:
             output(e)
         ok = False
+    finally:
+        if connect:
+            connect.close()
+
     return (ok, result)
 
 


### PR DESCRIPTION
This is a follow-up from https://github.com/trampgeek/jobe/pull/68

We had reperformance issues and decided to install a new server to replace the old one. When testing the new server I wanted hard number to compare between the installations, but the new server was so much better that the testsubmit.py failed in new ways:

1. It open to many connections so that the testing server OS did not allowed more open sockets.
The program then misbehaved when trying to close the connections that was not open.

Solution:  only close the connection if the there is a connection.

2. Testing takes a lot of time first double until fail, and then bisect to an exact value. This was not a problem on the old server where the range was not that big, but on the new server the range to backtrack through needs to many step, and there is no need to get that exact number

Solution: Add timeout for the tests, and add how many bisect steps should be tried to get highest good number.

Regards